### PR TITLE
Increase the mg->eg gradient for the PawnlessFlank malus

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -165,7 +165,7 @@ namespace {
   constexpr Score LongDiagonalBishop = S( 22,  0);
   constexpr Score MinorBehindPawn    = S( 16,  0);
   constexpr Score Overload           = S( 13,  6);
-  constexpr Score PawnlessFlank      = S( 20, 80);
+  constexpr Score PawnlessFlank      = S( 19, 84);
   constexpr Score RookOnPawn         = S(  8, 24);
   constexpr Score SliderOnQueen      = S( 42, 21);
   constexpr Score ThreatByKing       = S( 23, 76);


### PR DESCRIPTION
Just a change of value to S(19, 84). Also somewhat of a follow up
to the recent tweak in definition of KingFlank.

I tried a lot of other values before this, increasing and decreasing
but with little success, and before giving up I wanted to try tweaking
the middlegame and endgame values in the opposite directions. I guess
this is somewhat lucky.

STC:
LLR: 2.94 (-2.94,2.94) [0.00,4.00]
Total: 67685 W: 15399 L: 14963 D: 37323
http://tests.stockfishchess.org/tests/view/5b5b5ae80ebc5902bdb8e4f8

LTC: (Also thanks to Stephane Nicolet)
LLR: 2.95 (-2.94,2.94) [0.00,4.00]
Total: 54635 W: 9505 L: 9172 D: 35958
http://tests.stockfishchess.org/tests/view/5b5b78f20ebc5902bdb8ece5

Closes https://github.com/official-stockfish/Stockfish/pull/1714

Bench: 4883742